### PR TITLE
Pyvisa syntax update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ ENV/
 # custom
 playground.py
 .vscode
-socketscpi-venv
+socketscpi-venv*

--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,3 @@ Features
 
 * Free software: MIT License
 * Documentation: https://socketscpi.readthedocs.io/en/latest/index.html
-
-
-Credits
--------
-
-This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
-
-.. _Cookiecutter: https://github.com/audreyr/cookiecutter
-.. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -21,3 +21,8 @@ History
 ----------------------
 
 * Adjusted the error checking for the ``.query()`` method to account for SCPI queries that require additional arguments.
+
+2022.08.0 (2022-08-11)
+----------------------
+
+* Renamed ``binblockwrite()``, ``binblockread()``, and ``disconnect()`` to ``write_binary_values()``, ``read_binary_values()``, and ``close()``, respectively, to match the function calls in PyVISA.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,6 +24,10 @@ To check for and print out errors, do something like this::
     except socketscpi.SockInstError as e:
         print(str(e))
 
+When you're finished communicating with your instrument, close it gracefully like this::
+
+    instrument.close()
+
 ====================
 **SocketInstrument**
 ====================
@@ -45,11 +49,11 @@ Class constructor that connects to the test equipment and returns a SocketInstru
 * ``socketscpi.SocketInstrument``: Instrument object to be used for communication and control.
 
 
-**disconnect**
+**close**
 --------------
 ::
 
-    SocketInstrument.disconnect()
+    SocketInstrument.close()
 
 Gracefully closes socket connection.
 
@@ -131,11 +135,11 @@ Prints out all errors and clears error queue. Raises SockInstError with the info
 * None
 
 
-**binblockread**
-----------------
+**query_binary_values**
+-----------------------
 ::
 
-    SocketInstrument.binblockread(cmd, datatype='b')
+    SocketInstrument.query_binary_values(cmd, datatype='b')
 
 Sends a query and parses response in IEEE 488.2 binary block format.
 
@@ -149,11 +153,11 @@ Sends a query and parses response in IEEE 488.2 binary block format.
 * ``(NumPy ndarray)`` Array containing the data from the instrument buffer.
 
 
-**binblockwrite**
------------------
+**write_binary_values**
+-----------------------
 ::
 
-    SocketInstrument.binblockwrite(cmd, data)
+    SocketInstrument.write_binary_values(cmd, data)
 
 Sends a command and payload data in IEEE 488.2 binary block format.
 
@@ -161,7 +165,7 @@ Sends a command and payload data in IEEE 488.2 binary block format.
 
 * ``cmd`` ``(string)``: SCPI command used to send data to instrument as a binary block.
 * ``data`` ``(NumPy ndarray)``: Data to be sent to the instrument. Refer to the documentation of the SCPI command being used for correct argument formatting.
-* ``esr`` ``(bool)``: Determines whether to append an ESR query to the end of the binblockwrite for error checking purposes.
+* ``esr`` ``(bool)``: Determines whether to append an ESR query to the end of the binary block write for error checking purposes.
 
 **Returns**
 

--- a/examples.py
+++ b/examples.py
@@ -25,7 +25,7 @@ def awg_example(ipAddress, port=5025):
     wfm = np.array(2047 * np.sin(2 * np.pi * freq * t), dtype=np.int16) << 4
 
     awg.write(f'trace:def 1, {rl}')
-    awg.binblockwrite('trace:data 1, 0, ', wfm)
+    awg.write_binary_values('trace:data 1, 0, ', wfm)
 
     awg.write('trace:select 1')
     awg.write('init:cont on')
@@ -33,7 +33,7 @@ def awg_example(ipAddress, port=5025):
     awg.query('*opc?')
 
     awg.err_check()
-    awg.disconnect()
+    awg.close()
 
 
 def vna_example(ipAddress, port=5025):
@@ -58,14 +58,14 @@ def vna_example(ipAddress, port=5025):
     vna.write('format:border swap')
     vna.write('format real,64')
 
-    meas = vna.binblockread('calculate1:data? fdata', datatype='d')
+    meas = vna.query_binary_values('calculate1:data? fdata', datatype='d')
     vna.query('*opc?')
 
-    freq = vna.binblockread('calculate1:x?', datatype='d')
+    freq = vna.query_binary_values('calculate1:x?', datatype='d')
     vna.query('*opc?')
 
     vna.err_check()
-    vna.disconnect()
+    vna.close()
 
     return freq, meas
 
@@ -102,7 +102,7 @@ def scope_example(ipAddress):
     scope.write('digitize')
 
     # Transfer binary waveform data from scope
-    data = scope.binblockread('waveform:data?', datatype='b')
+    data = scope.query_binary_values('waveform:data?', datatype='b')
 
     # Query x and y values to scale the data appropriately for plotting
     xIncrement = float(scope.query('waveform:xincrement?'))
@@ -116,15 +116,15 @@ def scope_example(ipAddress):
     wfm = [(d * yIncrement) + yOrigin for d in data]
 
     # Check for errors
-    scope.disconnect()
+    scope.close()
 
     return time, wfm
 
 
 def main():
-    # awg_example('10.112.181.139', port=5025)
-    # vna_example('10.112.181.177', port=5025)
-    scope_example('141.121.210.161')
+    # awg_example('127.0.0.1', port=5025)
+    vna_example('127.0.0.1', port=5025)
+    # scope_example('141.121.210.161')
 
 if __name__ == '__main__':
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2021.07.0
+current_version = 2022.08.0
 commit = True
 tag = True
 
@@ -13,7 +13,7 @@ replace = __version__ = '{new_version}'
 
 [metadata]
 name = socketscpi
-version = 2021.07.0
+version = 2022.08.0
 author = Morgan Allison
 author_email = morgan.allison@keysight.com
 description = socketscpi provides a robust SCPI interface to electronic test and measurement equipment via raw socket protocol, removing the requirement for VISA and improving data transfer speed over VXI-11.

--- a/socketscpi/__init__.py
+++ b/socketscpi/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """Morgan Allison"""
 __email__ = 'morgan.allison@keysight.com'
-__version__ = '2021.07.0'
+__version__ = '2022.08.0'
 
 # For ease of use
 from socketscpi.socketscpi import *

--- a/socketscpi/socketscpi.py
+++ b/socketscpi/socketscpi.py
@@ -6,6 +6,7 @@ It handles sending commands, receiving query results,
 reading/writing binary block data, and checking for errors.
 """
 
+import warnings
 import socket
 import numpy as np
 import ipaddress
@@ -52,6 +53,13 @@ class SocketInstrument:
             pass
 
     def disconnect(self):
+        """DEPRECATED. THIS IS A PASS-THROUGH FUNCTION ONLY."""
+
+        warnings.warn("socketscpi.binblockread() is deprecated. Use socketscpi.query_binary_values() instead.")
+
+        return self.close()
+
+    def close(self):
         """Gracefully close socket connection."""
         self.socket.shutdown(socket.SHUT_RDWR)
         self.socket.close()
@@ -143,11 +151,15 @@ class SocketInstrument:
             raise SockInstError(err)
 
     def binblockread(self, cmd, datatype='b', debug=False, errCheck=True):
+        """DEPRECATED. THIS IS A PASS-THROUGH FUNCTION ONLY."""
+
+        warnings.warn("socketscpi.binblockread() is deprecated. Use socketscpi.query_binary_values() instead.")
+
+        return self.query_binary_values(cmd, datatype=datatype, debug=debug, errCheck=errCheck)
+
+    def query_binary_values(self, cmd, datatype='b', debug=False, errCheck=True):
         """
         Send a command and parses response in IEEE 488.2 binary block format.
-
-        cmd: string containing SCPI command
-        datatype:
 
         The waveform is formatted as:
         #<x><yyy><data><newline>, where:
@@ -265,6 +277,13 @@ class SocketInstrument:
         return f'#{len(str(numBytes))}{numBytes}'
 
     def binblockwrite(self, cmd, data, debug=False, errCheck=True):
+        """DEPRECATED. THIS IS A PASS-THROUGH FUNCTION ONLY."""
+
+        warnings.warn("socketscpi.binblockwrite() is deprecated. Use socketscpi.write_binary_values() instead.")
+
+        return self.write_binary_values(cmd, data, debug=debug, errCheck=errCheck)
+
+    def write_binary_values(self, cmd, data, debug=False, errCheck=True):
         """
         Sends a command and payload data with IEEE 488.2 binary block format
 


### PR DESCRIPTION
Renamed the following methods to match the function calls in PyVISA:
* ``binblockwrite()`` to ``write_binary_values()``
* ``binblockread()`` to ``read_binary_values()``
* ``disconnect()`` to ``close()``